### PR TITLE
add timeout parameter

### DIFF
--- a/qdl.c
+++ b/qdl.c
@@ -51,6 +51,7 @@
 #include <unistd.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
+#include <time.h>
 
 #include "qdl.h"
 #include "patch.h"
@@ -79,6 +80,7 @@ struct qdl_device {
 };
 
 bool qdl_debug;
+int qdl_usb_open_timeout;
 
 static int detect_type(const char *xml_file)
 {
@@ -285,13 +287,29 @@ static int usb_open(struct qdl_device *qdl)
 
 	fprintf(stderr, "Waiting for EDL device\n");
 
+	time_t t0 = time(0);
 	for (;;) {
 		fd_set rfds;
 
 		FD_ZERO(&rfds);
 		FD_SET(mon_fd, &rfds);
 
-		ret = select(mon_fd + 1, &rfds, NULL, NULL, NULL);
+		if (qdl_usb_open_timeout > 0) {
+			time_t t1 = time(0);
+			time_t diff = (time_t)difftime(t1, t0+(time_t)qdl_usb_open_timeout);
+			if(diff >= 0)
+			{
+				fprintf(stderr, "Waiting for EDL device: Timeout reached, exit with error\n");
+				return -2;
+			}
+			time_t timeout_sec = abs(diff);
+
+			struct timeval tv = {timeout_sec, 0};
+			ret = select(mon_fd + 1, &rfds, NULL, NULL, &tv);
+		} else {
+			ret = select(mon_fd + 1, &rfds, NULL, NULL, NULL);
+		}
+
 		if (ret < 0)
 			return -1;
 
@@ -425,6 +443,7 @@ int main(int argc, char **argv)
 		{"finalize-provisioning", no_argument, 0, 'l'},
 		{"storage", required_argument, 0, 's'},
 		{"multiplier", required_argument, 0, 'm'},
+		{"timeout", required_argument, 0, 't'},
 		{0, 0, 0, 0}
 	};
 
@@ -441,6 +460,9 @@ int main(int argc, char **argv)
 			break;
 		case 's':
 			storage = optarg;
+			break;
+		case 't':
+			qdl_usb_open_timeout = strtol(optarg, NULL, 10);
 			break;
 		case 'm':
 			qdl.multiplier = strtol(optarg, NULL, 10);
@@ -490,15 +512,24 @@ int main(int argc, char **argv)
 
 	ret = usb_open(&qdl);
 	if (ret)
+	{
+		fprintf(stderr, "usb_open failed with error code %d", ret);
 		return 1;
+	}
 
 	ret = sahara_run(&qdl, prog_mbn);
 	if (ret < 0)
+	{
+		fprintf(stderr, "sahara_run failed with error code %d", ret);
 		return 1;
+	}
 
 	ret = firehose_run(&qdl, incdir, storage);
 	if (ret < 0)
+	{
+		fprintf(stderr, "firehose_run failed with error code %d", ret);
 		return 1;
+	}
 
 	return 0;
 }

--- a/qdl.c
+++ b/qdl.c
@@ -421,7 +421,7 @@ static void print_usage(void)
 {
 	extern const char *__progname;
 	fprintf(stderr,
-		"%s [--debug] [--multiplier 1-2048] [--storage <emmc|nand|ufs>] [--finalize-provisioning] [--include <PATH>] <prog.mbn> [<program> <patch> ...]\n",
+		"%s [--debug] [--multiplier 1-2048] [--storage <emmc|nand|ufs>] [--finalize-provisioning] [--timeout <time_in_secs>] [--include <PATH>] <prog.mbn> [<program> <patch> ...]\n",
 		__progname);
 }
 


### PR DESCRIPTION
this can be used to avoid endless blocking in
seek call in case of no EDL device available